### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ dm-sonnet==1.23
 sympy
 scikit-learn
 scipy
-tensorflow
+tensorflow<2
 numpy
 networkx==2.3
-graph_nets
+graph_nets==1.0.4
 docopt
 pandas
 python-louvain


### PR DESCRIPTION
Fixing problems caused by new versions of libraries:
* TF 2 causes `Module 'tensorflow' has no attribute 'contrib'`
* graph_nets>1.0.4 falls on `graph.nodes.shape.as_list()[0]` for case `bethe_hessian_init=False` here:
https://github.com/deepmind/graph_nets/blob/9026c8b91068426a10aead9dada023fbb329ca43/graph_nets/blocks.py#L264